### PR TITLE
Use default port if not overridden by config.

### DIFF
--- a/hooktftp.go
+++ b/hooktftp.go
@@ -142,6 +142,10 @@ func main() {
 		HOOKS = append(HOOKS, hook)
 	}
 
+	if conf.Port == "" {
+		conf.Port = "69"
+	}
+
 	addr, err := net.ResolveUDPAddr("udp", ":"+conf.Port)
 	if err != nil {
 		fmt.Println("Failed to resolve address", err)


### PR DESCRIPTION
As it is, if you don't specify the port in the config, hooktftp listens to a random port's traffic.