### PR TITLE
Enlarge tftp request buffer size

### DIFF
--- a/tftp/server.go
+++ b/tftp/server.go
@@ -49,7 +49,7 @@ func NewTFTPServer(addr *net.UDPAddr) (*Server, error) {
 
 	return &Server{
 		conn,
-		make([]byte, 50),
+		make([]byte, 2048),
 	}, nil
 
 }


### PR DESCRIPTION
This raises the tftp buffer size to a reasonable value which handles the default ethernet mtu.
Should fix issue #5.