### PR TITLE
Add support for tsize/TransferSize option

### DIFF
--- a/src/tftp/parse_rrq.go
+++ b/src/tftp/parse_rrq.go
@@ -3,17 +3,19 @@ package tftp
 import (
 	"encoding/binary"
 	"fmt"
-	"strconv"
 	"net"
+	"strconv"
+
 	"logger"
 )
 
 type Request struct {
-	Opcode    uint16
-	Blocksize int
-	Mode      int
-	Path      string
-	Addr      *net.Addr
+	Opcode       uint16
+	Blocksize    int
+	TransferSize int
+	Mode         int
+	Path         string
+	Addr         *net.Addr
 }
 
 type RRQParseError struct {
@@ -74,6 +76,15 @@ func ParseRequest(data []byte) (*Request, error) {
 				return request, err
 			}
 			request.Blocksize = blocksize
+		case "tsize":
+			var tsizebytes []byte
+			tsizebytes, rest = sliceUpToNullByte(rest)
+			tsize, err := strconv.Atoi(string(tsizebytes))
+			if err != nil {
+				logger.Err("Failed to parse tsize %s", tsizebytes)
+				return request, err
+			}
+			request.TransferSize = tsize
 		default:
 			logger.Err("Unknown option: %s; data: %s", string(option), string(data))
 			// throw away unknown option value

--- a/src/tftp/rrq_response.go
+++ b/src/tftp/rrq_response.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"strconv"
 	"time"
+
 	"logger"
 )
 
@@ -16,13 +17,14 @@ type Connection interface {
 }
 
 type RRQresponse struct {
-	conn        Connection
-	buffer      []byte
-	pos         int
-	ack         []byte
-	Request     *Request
-	blocknum    uint16
-	badinternet bool
+	conn         Connection
+	buffer       []byte
+	pos          int
+	ack          []byte
+	Request      *Request
+	blocknum     uint16
+	badinternet  bool
+	TransferSize int
 }
 
 func (res *RRQresponse) SimulateBadInternet() bool {
@@ -139,6 +141,13 @@ func (res *RRQresponse) WriteOACK() error {
 	oackbuffer = append(oackbuffer, []byte(strconv.Itoa(res.Request.Blocksize))...)
 	oackbuffer = append(oackbuffer, 0)
 
+	if res.TransferSize != -1 {
+		oackbuffer = append(oackbuffer, []byte("tsize")...)
+		oackbuffer = append(oackbuffer, 0)
+		oackbuffer = append(oackbuffer, []byte(strconv.Itoa(res.TransferSize))...)
+		oackbuffer = append(oackbuffer, 0)
+	}
+
 	_, err := res.conn.Write(oackbuffer)
 	if err != nil {
 		return err
@@ -181,6 +190,7 @@ func NewRRQresponse(clientaddr *net.UDPAddr, request *Request, badinternet bool)
 		request,
 		0,
 		badinternet,
+		-1,
 	}, nil
 
 }

--- a/src/tftp/rrq_test.go
+++ b/src/tftp/rrq_test.go
@@ -31,6 +31,7 @@ func newRRQResonponse() (*RRQresponse, *MockConnection) {
 		RRQ,
 		5,
 		OCTET,
+		-1,
 		"/foo",
 		nil,
 	}
@@ -42,6 +43,7 @@ func newRRQResonponse() (*RRQresponse, *MockConnection) {
 		request,
 		0,
 		false,
+		-1,
 	}
 	return rrq, conn
 }


### PR DESCRIPTION
expose the tsize option in RRQresponse/Request structures. Some
clients send a tsize=0 option and will return an error unless this is
filled in with some value.